### PR TITLE
Add Cyrillic support to name abbreviation

### DIFF
--- a/Core/Helper.lua
+++ b/Core/Helper.lua
@@ -73,6 +73,25 @@ function UUF:ShortenName(name, nameBlacklist)
     return nameBlacklist[words[2]] and words[1] or words[#words] or name
 end
 
+local function getFirstUTF8Char(str)
+    if not str or str == "" then return "" end
+    
+    if string.utf8sub then
+        return string.utf8sub(str, 1, 1)
+    end
+
+    -- Hash map of locale to number of bytes for first UTF-8 character
+    local localeFirstCharBytes = {
+        koKR = 3, -- Korean
+        zhCN = 3, -- Simplified Chinese
+        zhTW = 3, -- Traditional Chinese
+        ruRU = 2, -- Russian
+        jaJP = 3, -- Japanese (if supported)
+    }
+    
+    return string.sub(str, 1, localeFirstCharBytes[GetLocale()] or 1)
+end
+
 function UUF:AbbreviateName(unitName)
     local unitNameParts = {}
     for word in unitName:gmatch("%S+") do
@@ -81,7 +100,7 @@ function UUF:AbbreviateName(unitName)
 
     local last = table.remove(unitNameParts)
     for i, word in ipairs(unitNameParts) do
-        unitNameParts[i] = (string.utf8sub or string.sub)(word, 1, 1) .. "."
+        unitNameParts[i] = getFirstUTF8Char(word) .. "."
     end
 
     table.insert(unitNameParts, last)

--- a/Core/Helper.lua
+++ b/Core/Helper.lua
@@ -214,7 +214,7 @@ function UUF:Substring(str, start, length)
     local bytesPerChar = localeFirstCharBytes[GetLocale()] or 1;
     local finalLength = length * bytesPerChar;
     if bytesPerChar > 1 then
-        local oneByteSymbols = CountOneByteSymbols(str, start, length * bytesPerChar);
+        local oneByteSymbols = CountOneByteSymbols(str, start, length, bytesPerChar);
         finalLength = oneByteSymbols + (length - oneByteSymbols) * bytesPerChar;
     end
     if string.utf8sub then
@@ -223,16 +223,24 @@ function UUF:Substring(str, start, length)
     return string.sub(str, start, finalLength)
 end
 
-function CountOneByteSymbols(str, start, length)
+function CountOneByteSymbols(str, start, length, bytesPerChar)
     if not str then return 0 end
-    local endPos = math.min(start + length - 1, #str)
+    local endPos = math.min(start + length * bytesPerChar - 1, #str)
     local count = 0
+    local lettersCount = 0
     for i = start, endPos do
         local char = str:sub(i, i)
         -- Count characters that have a weight of exactly 1 byte (ASCII range 0-127)
         if string.byte(char) <= 127 then
             count = count + 1
+            lettersCount = lettersCount + 1
+        else
+            lettersCount = lettersCount + 1 / bytesPerChar
+        end
+        if lettersCount >= length then
+            break
         end
     end
+
     return count
 end

--- a/Core/Helper.lua
+++ b/Core/Helper.lua
@@ -225,7 +225,7 @@ end
 
 function CountOneByteSymbols(str, start, length)
     if not str then return 0 end
-    local endPos = start + length - 1
+    local endPos = math.min(start + length - 1, #str)
     local count = 0
     for i = start, endPos do
         local char = str:sub(i, i)

--- a/Units/Modules/Tags.lua
+++ b/Units/Modules/Tags.lua
@@ -202,21 +202,21 @@ end
 oUF.Tags.Methods["Name:VeryShort"] = function(unit)
     local name = UnitName(unit)
     if name then 
-        return string.sub(name, 1, 5)
+        return UUF:Substring(name, 1, 5)
     end
 end
 
 oUF.Tags.Methods["Name:Short"] = function(unit)
     local name = UnitName(unit)
     if name then 
-        return string.sub(name, 1, 8)
+        return UUF:Substring(name, 1, 8)
     end
 end
 
 oUF.Tags.Methods["Name:Medium"] = function(unit)
     local name = UnitName(unit)
     if name then 
-        return string.sub(name, 1, 10)
+        return UUF:Substring(name, 1, 10)
     end
 end
 
@@ -243,19 +243,19 @@ if NSM then
 	oUF.Tags.Methods['NSNickName:veryshort'] = function(unit)
 		local name = UnitName(unit)
 		name = name and NSAPI and NSAPI:GetName(name, "Unhalted") or name
-		return string.sub(name, 1, 5)
+		return UUF:Substring(name, 1, 5)
 	end
 
 	oUF.Tags.Methods['NSNickName:short'] = function(unit)
 		local name = UnitName(unit)
 		name = name and NSAPI and NSAPI:GetName(name, "Unhalted") or name
-		return string.sub(name, 1, 8)
+		return UUF:Substring(name, 1, 8)
 	end
 
 	oUF.Tags.Methods['NSNickName:medium'] = function(unit)
 		local name = UnitName(unit)
 		name = name and NSAPI and NSAPI:GetName(name, "Unhalted") or name
-		return string.sub(name, 1, 10)
+		return UUF:Substring(name, 1, 10)
 	end
 
     for i = 1, 12 do
@@ -264,7 +264,7 @@ if NSM then
             local name = UnitName(unit)
             name = name and NSAPI and NSAPI:GetName(name, "Unhalted") or name
             if name and unit then
-                return string.sub(name, 1, i)
+                return UUF:Substring(name, 1, i)
             end
         end
     end


### PR DESCRIPTION
Issue: Name abbreviation function was breaking Cyrillic and other non-Latin characters
Fix: Added proper UTF-8 character support with client locale detection
Impact: Russian, Chinese, Korean, and Japanese player names now display correctly when abbreviated