### PR TITLE
Expose UUF API for external addon access

### DIFF
--- a/Core/Main.lua
+++ b/Core/Main.lua
@@ -10,6 +10,9 @@ function UnhaltedUF:OnInitialize()
         end
     end
     UUF.HealthSeparator = UUF.db.profile.General.HealthSeparator or "-"
+
+    -- Allow other addons to access UUF namespace
+    self.API = UUF
 end
 
 function UnhaltedUF:OnEnable()


### PR DESCRIPTION
Added API access for other addons to the UUF namespace. Allows e.g. setting nicknames through other addons without users having to mess with tags