### PR TITLE
Fix castbar not showing non-interruptible color

### DIFF
--- a/Elements/CastBar.lua
+++ b/Elements/CastBar.lua
@@ -292,7 +292,13 @@ function UUF:CreateTestCastBar(unitFrame, unit)
             unitFrame.Castbar.Text:SetText(ShortenCastName("Ethereal Portal", UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].CastBar.Text.SpellName.MaxChars))
             unitFrame.Castbar.Time:SetText("0.0")
             unitFrame.Castbar:SetMinMaxValues(0, 1000)
-            unitFrame.Castbar:SetScript("OnUpdate", function() local currentValue = unitFrame.Castbar:GetValue() currentValue = currentValue + 1 if currentValue >= 1000 then currentValue = 0 end unitFrame.Castbar:SetValue(currentValue) unitFrame.Castbar.Time:SetText(string.format("%.1f", (currentValue / 1000) * 5)) end)
+            unitFrame.Castbar.testValue = 0 -- Track value ourselves since GetValue() returns a secret
+            unitFrame.Castbar:SetScript("OnUpdate", function(self)
+                self.testValue = (self.testValue or 0) + 1
+                if self.testValue >= 1000 then self.testValue = 0 end
+                self:SetValue(self.testValue)
+                unitFrame.Castbar.Time:SetText(string.format("%.1f", (self.testValue / 1000) * 5))
+            end)
             unitFrame.Castbar:SetStatusBarColor(unpack(CastBarDB.Foreground))
             -- Hide the non-interruptible overlay in test mode (test shows interruptible cast)
             if unitFrame.Castbar.NotInterruptibleOverlay then


### PR DESCRIPTION
## Summary

- Fixes the castbar not displaying the non-interruptible color in WoW's Midnight expansion
- The `notInterruptible` value from `UnitCastingInfo()` is now a "secret value" that cannot be directly accessed or passed to `SetStatusBarColor()` in tainted execution contexts

## Solution

Uses an overlay texture approach that works with WoW's secret value system:
- Creates a `NotInterruptibleOverlay` texture anchored to the status bar fill, colored with `NotInterruptibleColour`
- Uses `SetAlphaFromBoolean()` to toggle overlay visibility, which can handle secret boolean values from the WoW API
- When `notInterruptible=true` → overlay visible → shows non-interruptible color
- When `notInterruptible=false` → overlay hidden → shows normal foreground color

## Additional Changes

- Adds `PostCastInterruptible` callback to handle mid-cast state changes
- Fixes potential nil error when accessing spell info
- Updates `UpdateUnitCastBar` to sync overlay color with settings
- Updates test mode to properly hide the overlay

## Test plan

- [x] Target an enemy casting an interruptible spell - should show foreground color
- [x] Target an enemy casting a non-interruptible spell - should show NotInterruptibleColour
- [x] Change NotInterruptibleColour in settings - should update immediately
- [x] Test castbar test mode - should show interruptible (foreground) color

Fixes #160

🤖 Generated with [Claude Code](https://claude.ai/code)