### PR TITLE
Update CastBar.lua for more visible pips on empowered spells.

### DIFF
--- a/Elements/CastBar.lua
+++ b/Elements/CastBar.lua
@@ -34,6 +34,14 @@ function UUF:CreateUnitCastBar(unitFrame, unit)
     CastBar:SetFrameLevel(CastBarContainer:GetFrameLevel() + 1)
     CastBar:SetStatusBarColor(unpack(CastBarDB.Foreground))
 
+    CastBar.CreatePip = function(element, stage)
+        local texture = element:CreateTexture(nil, 'OVERLAY', 'CastingBarFrameStagePipTemplate', 1)
+        texture:SetParent(element)
+        texture:SetColorTexture(1, 1, 1)
+        texture:SetSize(2, element:GetHeight()) -- A simple vertical line
+        return texture
+    end
+
     CastBar.Background = CastBar:CreateTexture(nil, "BACKGROUND")
     CastBar.Background:SetAllPoints(CastBar)
     CastBar.Background:SetTexture(UUF.Media.Background)


### PR DESCRIPTION
This is very crude, but a workable quick fix until you have time to do it properly.

<img width="291" height="88" alt="image" src="https://github.com/user-attachments/assets/0e934836-f160-4a9b-a4c7-2c17725b4044" />

My apologies, I would have preferred to just submit a feature request, but could find no path on the discord or here.

Love your work, thanks for all the effort, it is greatly appreciated.