### PR TITLE
Fix [class] tag to only return player class not npc names

### DIFF
--- a/Libraries/oUF/elements/tags.lua
+++ b/Libraries/oUF/elements/tags.lua
@@ -444,7 +444,16 @@ local tagFuncs = setmetatable(
 		curpp = UnitPower,
 		maxhp = UnitHealthMax,
 		maxpp = UnitPowerMax,
-		class = UnitClass,
+		class = function(unit)
+			if UnitIsPlayer(unit) then
+				local _, class = UnitClass(unit)
+				return class
+			end
+		end,
+
+		faction = UnitFactionGroup,
+		race = UnitRace,
+	},
 		faction = UnitFactionGroup,
 		race = UnitRace,
 	},


### PR DESCRIPTION
the tag [class] returns names when selecting a npc, this change make it so it only returns class when a player is selected and nothing else.