### PR TITLE
Fix missing tooltip after respec

### DIFF
--- a/Core/UnitFrame.lua
+++ b/Core/UnitFrame.lua
@@ -5,8 +5,8 @@ local function ApplyScripts(unitFrame)
     unitFrame:RegisterForClicks("AnyUp")
     unitFrame:SetAttribute("*type1", "target")
     unitFrame:SetAttribute("*type2", "togglemenu")
-    unitFrame:HookScript("OnEnter", UnitFrame_OnEnter)
-    unitFrame:HookScript("OnLeave", UnitFrame_OnLeave)
+    unitFrame:SetScript("OnEnter", UnitFrame_OnEnter)
+    unitFrame:SetScript("OnLeave", UnitFrame_OnLeave)
 end
 
 function UUF:CreateUnitFrame(unitFrame, unit)
@@ -25,11 +25,11 @@ function UUF:CreateUnitFrame(unitFrame, unit)
     if unit == "player" or unit == "target" then UUF:CreateUnitCombatIndicator(unitFrame, unit) end
     if unit == "player" then UUF:CreateUnitRestingIndicator(unitFrame, unit) end
     -- if unit == "player" then UUF:CreateUnitTotems(unitFrame, unit) end
-    UUF:CreateUnitMouseoverIndicator(unitFrame, unit)
     UUF:CreateUnitTargetGlowIndicator(unitFrame, unit)
     UUF:CreateUnitAuras(unitFrame, unit)
     UUF:CreateUnitTags(unitFrame, unit)
     ApplyScripts(unitFrame)
+    UUF:CreateUnitMouseoverIndicator(unitFrame, unit)
     return unitFrame
 end
 

--- a/Elements/Indicators/Mouseover.lua
+++ b/Elements/Indicators/Mouseover.lua
@@ -28,8 +28,11 @@ function UUF:CreateUnitMouseoverIndicator(unitFrame, unit)
 
     MouseoverHighlight:Hide()
     MouseoverHighlight:SetFrameLevel(unitFrame.Health:GetFrameLevel() + 3)
-    unitFrame:SetScript("OnEnter", function() local DB = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Indicators.Mouseover if DB.Enabled then MouseoverHighlight:Show() end end)
-    unitFrame:SetScript("OnLeave", function() local DB = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Indicators.Mouseover if DB.Enabled then MouseoverHighlight:Hide() end end)
+    if not unitFrame.Mouseover_hooked then
+        unitFrame.Mouseover_hooked = true
+        unitFrame:HookScript("OnEnter", function() local DB = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Indicators.Mouseover if DB.Enabled then MouseoverHighlight:Show() end end)
+        unitFrame:HookScript("OnLeave", function() local DB = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Indicators.Mouseover if DB.Enabled then MouseoverHighlight:Hide() end end)
+    end
 
     return MouseoverHighlight
 end
@@ -62,8 +65,6 @@ function UUF:UpdateUnitMouseoverIndicator(unitFrame, unit)
     else
         if unitFrame.MouseoverHighlight then
             unitFrame.MouseoverHighlight:Hide()
-            unitFrame:SetScript("OnEnter", nil)
-            unitFrame:SetScript("OnLeave", nil)
             unitFrame.MouseoverHighlight = nil
         end
     end


### PR DESCRIPTION
### Problem

After a respec, unit frames no longer show their tooltip

### Details

During unit frame creation and after a change in player specialization (and maybe some other conditions as well), `UUF:CreateUnitMouseoverIndicator(unitFrame, unit)` (in Mouseover.lua) is called, which uses `unitFrame:SetScript("OnEnter", ...)` to set a mouse hover function. This function is then hooked in UnitFrame.lua (using `unitFrame:HookScript`) to also show a tooltip via Blizzard's `UnitFrame_OnEnter`.

But `UUF:CreateUnitMouseoverIndicator` will be called again after each respec, which will then set a *new* OnEnter script.

However, `UnitFrame_OnEnter` is only hooked to the very first OnEnter script function, and when the latter is overwritten with a new one, `UnitFrame_OnEnter` will never be called again.

### Fix

Use `SetScript` right in UnitFrame.lua, since we will always want to have a tooltip. Use `HookScript` in Mouseover.lua instead and only use it once.

I'm not sure about the variable naming guidelines, so feel free to mess around with this code.
