### PR TITLE
Fixes #241 - ADDON_ACTION_BLOCKED errors from ClearAllPoints()

### DIFF
--- a/Elements/HealthBar.lua
+++ b/Elements/HealthBar.lua
@@ -68,16 +68,23 @@ function UUF:UpdateUnitHealthBar(unitFrame, unit)
     local DispelHighlightDB = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].HealthBar.DispelHighlight
 
     if unitFrame then
-        unitFrame:ClearAllPoints()
-        unitFrame:SetSize(FrameDB.Width, FrameDB.Height)
-        if unit == "player" or unit == "target" then
-            local parentFrame = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].HealthBar.AnchorToCooldownViewer and _G["UUF_CDMAnchor"] or UIParent
-            UUF[unit:upper()]:SetPoint(FrameDB.Layout[1], parentFrame, FrameDB.Layout[2], FrameDB.Layout[3], FrameDB.Layout[4])
-            UUF[unit:upper()]:SetSize(FrameDB.Width, FrameDB.Height)
-        elseif unit == "targettarget" or unit == "focus" or unit == "focustarget" or unit == "pet" then
-            local parentFrame = _G[UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Frame.AnchorParent] or UIParent
-            UUF[unit:upper()]:SetPoint(FrameDB.Layout[1], parentFrame, FrameDB.Layout[2], FrameDB.Layout[3], FrameDB.Layout[4])
-            UUF[unit:upper()]:SetSize(FrameDB.Width, FrameDB.Height)
+        local isProtectedFrame = unitFrame.IsProtected and unitFrame:IsProtected()
+        local canChangeLayout = not (isProtectedFrame and InCombatLockdown())
+
+        if canChangeLayout then
+            unitFrame:ClearAllPoints()
+            unitFrame:SetSize(FrameDB.Width, FrameDB.Height)
+            if unit == "player" or unit == "target" then
+                local parentFrame = UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].HealthBar.AnchorToCooldownViewer and _G["UUF_CDMAnchor"] or UIParent
+                UUF[unit:upper()]:SetPoint(FrameDB.Layout[1], parentFrame, FrameDB.Layout[2], FrameDB.Layout[3], FrameDB.Layout[4])
+                UUF[unit:upper()]:SetSize(FrameDB.Width, FrameDB.Height)
+            elseif unit == "targettarget" or unit == "focus" or unit == "focustarget" or unit == "pet" then
+                local parentFrame = _G[UUF.db.profile.Units[UUF:GetNormalizedUnit(unit)].Frame.AnchorParent] or UIParent
+                UUF[unit:upper()]:SetPoint(FrameDB.Layout[1], parentFrame, FrameDB.Layout[2], FrameDB.Layout[3], FrameDB.Layout[4])
+                UUF[unit:upper()]:SetSize(FrameDB.Width, FrameDB.Height)
+            end
+        else
+            UUF:QueueCombatLayoutUpdate(unit)
         end
     end
 


### PR DESCRIPTION
Fixes #241 

- Prevent ADDON_ACTION_BLOCKED errors caused by calling protected layout APIs like `ClearAllPoints()` on secure frames while in combat lock down. 
- These layout updates can be triggered by profile/spec/level-up refresh paths that call `UpdateAllUnitFrames()` while the player is in combat.

Description
- Added a deferred update queue (`pendingCombatLayoutUpdates`) and a flush handler (`FlushPendingCombatLayoutUpdates`) that reapplies layout changes after combat ends (`PLAYER_REGEN_ENABLED`).
- Exposed `UUF:QueueCombatLayoutUpdate(unit)` to enqueue units whose layout updates must be deferred until after combat.
- Guarded the layout section of `UUF:UpdateUnitHealthBar` to detect protected frames via `unitFrame:IsProtected()` and `InCombatLockdown()`, and defer re-anchoring/resizing instead of calling `ClearAllPoints`/`SetPoint`/`SetSize` during combat.
- Changed files: `Core/UnitFrame.lua` (deferred queue and flush logic) and `Elements/HealthBar.lua` (combat-safe layout guard and queueing).