### PR TITLE
Fix #256 Pet's Anchor Parent not saving

### DIFF
--- a/Core/Config/GUI.lua
+++ b/Core/Config/GUI.lua
@@ -622,7 +622,7 @@ local function CreateFrameSettings(containerParent, unit, unitHasParent, updateC
         AnchorParentEditBox:SetText(FrameDB.AnchorParent or "")
         AnchorParentEditBox:SetRelativeWidth(0.33)
         AnchorParentEditBox:DisableButton(true)
-        AnchorParentEditBox:SetCallback("OnEnterPressed", function(_, _, value) FrameDB.AnchorParent = value ~= "" and value or nil AnchorParentEditBox:SetText(FrameDB.AnchorParent or "") updateCallback() end)
+        AnchorParentEditBox:SetCallback("OnEnterPressed", function(_, _, value) FrameDB.AnchorParent = value AnchorParentEditBox:SetText(FrameDB.AnchorParent or "") updateCallback() end)
         LayoutContainer:AddChild(AnchorParentEditBox)
     end
 


### PR DESCRIPTION
**Fix AnchorParent reset on relog**

When clearing AnchorParent in the GUI, it was being saved as nil.
On reload/login, this caused AceDB to fall back to the default ("UUF_PLAYER").

This change persists an empty string instead of nil, preventing default restoration while preserving existing fallback behavior to UIParent.

Tested:
- Clearing AnchorParent
- Reload UI
- Full logout/login
- Pet frame no longer resets