### PR TITLE
use oUF "TempLoss" to display temporary max health loss

### DIFF
--- a/Elements/HealthBar.lua
+++ b/Elements/HealthBar.lua
@@ -37,6 +37,14 @@ function UUF:CreateUnitHealthBar(unitFrame, unit)
         end
 
         unitFrame.Health = HealthBar
+        if unit ~= "boss" then
+            local TempLoss = CreateFrame('StatusBar', nil, HealthBar)
+            TempLoss:SetStatusBarTexture('UI-HUD-UnitFrame-Target-PortraitOn-Bar-TempHPLoss')
+            TempLoss:SetReverseFill(true)
+            TempLoss:SetAllPoints()
+            TempLoss:SetFrameLevel(HealthBar:GetFrameLevel() + 1)
+            HealthBar.TempLoss = TempLoss
+        end
 
         unitFrame.Health.PostUpdate = function(_, _, curHP, maxHP)
             local unitHP = unitFrame.HealthBackground


### PR DESCRIPTION
Since the default raid frames also show an overlay to indicate temporarily missing max hp, and oUF already has this implemented, we can just use it.

Screenshot of how it would look ingame (tested in the Kriegval's Rest delve):

![temp-hp-loss-screenshot](https://github.com/user-attachments/assets/49a5c7d2-284b-4c81-8555-63d2491a1d0e)
