### PR TITLE
FEAT: Toggle login message

### DIFF
--- a/Core/Config/GUI.lua
+++ b/Core/Config/GUI.lua
@@ -249,6 +249,15 @@ local function BuildMainNavigationTree()
 end
 
 local function CreateUIScaleSettings(containerParent)
+    local ToggleContainer = GUIWidgets.CreateInlineGroup(containerParent, "Login Message")
+
+    local Toggle = AG:Create("CheckBox")
+    Toggle:SetLabel("Display Login Message")
+    Toggle:SetValue(UUF.db.profile.General.DisplayLoginMessage)
+    Toggle:SetCallback("OnValueChanged", function(_, _, value) UUF.db.profile.General.DisplayLoginMessage = value end)
+    Toggle:SetRelativeWidth(0.33)
+    ToggleContainer:AddChild(Toggle)
+
     local Container = GUIWidgets.CreateInlineGroup(containerParent, "UI Scale")
     GUIWidgets.CreateInformationTag(Container,"These options allow you to adjust the UI Scale beyond the means that |cFF00B0F7Blizzard|r provides. If you encounter issues, please |cFFFF4040disable|r this feature.")
 

--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -8,6 +8,7 @@ local Defaults = {
     },
     profile = {
         General = {
+            DisplayLoginMessage = true,
             TagUpdateInterval = 0.25,
             Separator = "||",
             ToTSeparator = "»",

--- a/Core/Globals.lua
+++ b/Core/Globals.lua
@@ -100,7 +100,7 @@ local function SetupSlashCommands()
     SLASH_UUF2 = "/unhaltedunitframes"
     SLASH_UUF3 = "/uf"
     SlashCmdList["UUF"] = function() UUF:CreateGUI() end
-    UUF:PrettyPrint("'|cFF8080FF/uuf|r' for in-game configuration.")
+    if UUF.db.profile.General.DisplayLoginMessage then UUF:PrettyPrint("'|cFF8080FF/uuf|r' for in-game configuration.") end
 
     -- RL command
     SLASH_UUFRELOAD1 = "/rl"


### PR DESCRIPTION
Ported this over from BCDM (hope you don't mind!)

The code is almost entirely yours already; I've copy/pasted it and matched the value hierarchy.

I have moved the menu option to 'general' from 'global' as in this context global seems to mean 'affects all frames' and this is tangential to the other settings. 